### PR TITLE
Allow tum.key=NULL for scRNA in runTed.R

### DIFF
--- a/TED/R/runTed.R
+++ b/TED/R/runTed.R
@@ -287,7 +287,6 @@ run.Ted <- function(ref.dat,
 	}
 	if(input.type=="scRNA"){
 		stopifnot(nrow(ref.dat)==length(pheno.labels))
-		stopifnot(!is.null(tum.key))
 		
 		processed.dat <- process_scRNA (ref= ref.dat,
 										mixture=X, 


### PR DESCRIPTION
Removes condition that stops command if tum.key = NULL  and input.type is "scRNA"