### PR TITLE
Allow separate parallelization parameters for "correct batch effect" and other phases

### DIFF
--- a/TED/R/runTed.R
+++ b/TED/R/runTed.R
@@ -116,6 +116,7 @@ run.Ted.main <- function(input.phi,
 				    opt.control=list(trace=0, maxit= 100000),
 				    file.name=NULL,
 				    n.cores=1,
+				    n.cores.batch = n.cores.batch,
 				    tum.idx,
 				    sig.gene=NULL, 
 				    pdf.name=NULL,
@@ -134,6 +135,7 @@ run.Ted.main <- function(input.phi,
 				 gibbs.control= gibbs.control,
 				 opt.control= opt.control,
 				 n.cores= n.cores,
+				 n.cores.batch = n.cores.batch,
 				 sig.gene= sig.gene)
 	
 	

--- a/TED/R/runTed.R
+++ b/TED/R/runTed.R
@@ -158,7 +158,7 @@ run.Ted.main <- function(input.phi,
 					   			Zkg = first.gibbs.res $Zkg[-tum.idx,],
 					   			prior.mat = env.prior.mat,
 					   			opt.control = opt.control,
-					   			n.cores = round(n.cores/4))
+					   			n.cores = n.cores)
 					   			
 		phi.env.batch.corrected <- transform.phi.mat(input.phi = input.phi[-tum.idx,], log.fold = batch.opt.res $opt.psi)
 
@@ -215,7 +215,7 @@ run.Ted.main <- function(input.phi,
 					   			Zkg = first.gibbs.res $Zkg,
 					   			prior.mat = env.prior.mat,
 					   			opt.control = opt.control,
-					   			n.cores = round(n.cores/4))
+					   			n.cores = n.cores)
 					   			
 		phi.env.batch.corrected <- transform.phi.mat(input.phi = input.phi, log.fold = batch.opt.res $opt.psi)
 		

--- a/TED/R/runTed.R
+++ b/TED/R/runTed.R
@@ -158,7 +158,7 @@ run.Ted.main <- function(input.phi,
 					   			Zkg = first.gibbs.res $Zkg[-tum.idx,],
 					   			prior.mat = env.prior.mat,
 					   			opt.control = opt.control,
-					   			n.cores = n.cores)
+					   			n.cores = round(n.cores/4))
 					   			
 		phi.env.batch.corrected <- transform.phi.mat(input.phi = input.phi[-tum.idx,], log.fold = batch.opt.res $opt.psi)
 
@@ -215,7 +215,7 @@ run.Ted.main <- function(input.phi,
 					   			Zkg = first.gibbs.res $Zkg,
 					   			prior.mat = env.prior.mat,
 					   			opt.control = opt.control,
-					   			n.cores = n.cores)
+					   			n.cores = round(n.cores/4))
 					   			
 		phi.env.batch.corrected <- transform.phi.mat(input.phi = input.phi, log.fold = batch.opt.res $opt.psi)
 		

--- a/TED/R/runTed.R
+++ b/TED/R/runTed.R
@@ -138,6 +138,8 @@ run.Ted.main <- function(input.phi,
 	
 	
 	print("run first sampling")
+	core_report = paste0("Using ",n.cores," cores")
+	print(core_report)
 		
 	first.gibbs.res <- run.gibbs (input.phi= input.phi, 
 					  			  X=X,
@@ -149,6 +151,8 @@ run.Ted.main <- function(input.phi,
 	if(first.gibbs.only) return(list(para= para, res= list(first.gibbs.res= first.gibbs.res)))
 	
 	print("correct batch effect")
+	core_report = paste0("Using ",n.cores.batch," cores")
+	print(core_report)
 	env.prior.num <- -1 / (2* sigma ^2)
 	env.prior.mat <- matrix(env.prior.num, nrow= nrow(input.phi)-length(tum.idx), ncol=ncol(input.phi))
 	
@@ -158,7 +162,7 @@ run.Ted.main <- function(input.phi,
 					   			Zkg = first.gibbs.res $Zkg[-tum.idx,],
 					   			prior.mat = env.prior.mat,
 					   			opt.control = opt.control,
-					   			n.cores = n.cores)
+					   			n.cores = n.cores.batch)
 					   			
 		phi.env.batch.corrected <- transform.phi.mat(input.phi = input.phi[-tum.idx,], log.fold = batch.opt.res $opt.psi)
 
@@ -215,11 +219,13 @@ run.Ted.main <- function(input.phi,
 					   			Zkg = first.gibbs.res $Zkg,
 					   			prior.mat = env.prior.mat,
 					   			opt.control = opt.control,
-					   			n.cores = n.cores)
+					   			n.cores = n.cores.batch)
 					   			
 		phi.env.batch.corrected <- transform.phi.mat(input.phi = input.phi, log.fold = batch.opt.res $opt.psi)
 		
 		print("run final sampling")
+		core_report = paste0("Using ",n.cores," cores")
+		print(core_report)
 
 		final.gibbs.res <- run.gibbs (input.phi= phi.env.batch.corrected, 
 					  			  X=X,
@@ -254,6 +260,7 @@ run.Ted <- function(ref.dat,
 				opt.control=list(trace=0, maxit= 100000),
 				file.name=NULL,
 				n.cores=1,
+				n.cores.batch = NULL,
 				sig.gene=NULL,
 				pdf.name=NULL,
 				first.gibbs.only=F){
@@ -267,6 +274,10 @@ run.Ted <- function(ref.dat,
 	ref.dat <- ref.dat[,apply(ref.dat,2,function(ref.dat.gene.i) as.logical(prod(is.numeric (ref.dat.gene.i),is.finite (ref.dat.gene.i))))]
 	X <- X[,apply(X,2,function(X.gene.i) as.logical (prod(is.numeric (X.gene.i), is.finite (X.gene.i))))]
 	
+	#process parallelization options
+	if(is.null(n.cores.batch)){
+	  n.cores.batch = n.cores
+	}
 	
 	print("removing outlier genes...")
 	X.norm <- apply(X,1,function(vec)vec/sum(vec))
@@ -315,6 +326,7 @@ run.Ted <- function(ref.dat,
 			 	  opt.control= opt.control,
 			 	  file.name= file.name,
 			 	  n.cores= n.cores,
+			 	  n.cores.batch = n.cores.batch,
 			 	  tum.idx= tum.idx,
 			 	  sig.gene= sig.gene,
 			 	  pdf.name= pdf.name,

--- a/TED/R/runTed.R
+++ b/TED/R/runTed.R
@@ -140,8 +140,6 @@ run.Ted.main <- function(input.phi,
 	
 	
 	print("run first sampling")
-	core_report = paste0("Using ",n.cores," cores")
-	print(core_report)
 		
 	first.gibbs.res <- run.gibbs (input.phi= input.phi, 
 					  			  X=X,
@@ -153,8 +151,6 @@ run.Ted.main <- function(input.phi,
 	if(first.gibbs.only) return(list(para= para, res= list(first.gibbs.res= first.gibbs.res)))
 	
 	print("correct batch effect")
-	core_report = paste0("Using ",n.cores.batch," cores")
-	print(core_report)
 	env.prior.num <- -1 / (2* sigma ^2)
 	env.prior.mat <- matrix(env.prior.num, nrow= nrow(input.phi)-length(tum.idx), ncol=ncol(input.phi))
 	
@@ -226,8 +222,6 @@ run.Ted.main <- function(input.phi,
 		phi.env.batch.corrected <- transform.phi.mat(input.phi = input.phi, log.fold = batch.opt.res $opt.psi)
 		
 		print("run final sampling")
-		core_report = paste0("Using ",n.cores," cores")
-		print(core_report)
 
 		final.gibbs.res <- run.gibbs (input.phi= phi.env.batch.corrected, 
 					  			  X=X,


### PR DESCRIPTION
In my implementation of run.Ted() (Rstudio on interactive node of Scientific Linux-based cluster), I notice that the "correct batch effect" phase of run.Ted() draws a lot more CPU than the "run first sampling" or "run final sampling" phases. For instance, even running with just n.cores = 3 on a cluster node with 32 available cores, enough CPU power is used by run.Ted() during this phase that the load raises high enough (>70 on our cluster) to send the entire node into an alarm state. The load raises precipitously with higher n.cores in this phase. However, during the other phases (first and final sampling), the load remains quite small (~5-6), even with many more cores (n.cores =12).

To allow for quick sampling and to minimize the load during the correct batch effect phase, I have modified this function to allow for a seperate parameter which specifies the number of cores for the batch effect phase (n.cores.batch) in addition to the n.cores parameter- For instance I can use run.Ted() with n.cores = 12 and n.cores.batch = 2, which seems to work well for my setup. I have constructed this so n.cores.batch defaults to the value of n.cores if it is not specified by the user, so the default usage need not change for setups where this modification is not needed.

I am not sure why the CPU load differs so much in my use case, and I'm wondering whether it's specific to my setup- perhaps something to do with running it on a qrsh node from Rstudio. In any case, I've found these changes very useful for my set-up, and figured I'd generate a pull request in case you wanted to merge it into your code as well. Or if this is only a problem on my set-up I'll just keep it on my fork :)